### PR TITLE
Домашняя работа №7

### DIFF
--- a/bot/pom.xml
+++ b/bot/pom.xml
@@ -132,6 +132,30 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
+
+        <!-- Bucket4j -->
+        <dependency>
+            <groupId>com.giffing.bucket4j.spring.boot.starter</groupId>
+            <artifactId>bucket4j-spring-boot-starter</artifactId>
+        </dependency>
+
+        <!-- Cache -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-cache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.cache</groupId>
+            <artifactId>cache-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>jcache</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/bot/src/main/java/edu/java/bot/BotApplication.java
+++ b/bot/src/main/java/edu/java/bot/BotApplication.java
@@ -1,12 +1,13 @@
 package edu.java.bot;
 
 import edu.java.bot.configuration.ApplicationConfig;
+import edu.java.bot.configuration.RetryConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 @SpringBootApplication
-@EnableConfigurationProperties(ApplicationConfig.class)
+@EnableConfigurationProperties({ApplicationConfig.class, RetryConfig.class})
 public class BotApplication {
     public static void main(String[] args) {
         SpringApplication.run(BotApplication.class, args);

--- a/bot/src/main/java/edu/java/bot/BotApplication.java
+++ b/bot/src/main/java/edu/java/bot/BotApplication.java
@@ -5,9 +5,11 @@ import edu.java.bot.configuration.RetryConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cache.annotation.EnableCaching;
 
 @SpringBootApplication
 @EnableConfigurationProperties({ApplicationConfig.class, RetryConfig.class})
+@EnableCaching
 public class BotApplication {
     public static void main(String[] args) {
         SpringApplication.run(BotApplication.class, args);

--- a/bot/src/main/java/edu/java/bot/client/scrapper/ScrapperClient.java
+++ b/bot/src/main/java/edu/java/bot/client/scrapper/ScrapperClient.java
@@ -11,13 +11,11 @@ import edu.java.bot.repository.ChatLinkRepository;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatusCode;
-import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
-@Service
 public class ScrapperClient extends AbstractJsonWebClient implements ChatLinkRepository {
 
     private static final String TG_CHAT_URI = "/tg-chat/{id}";

--- a/bot/src/main/java/edu/java/bot/configuration/ApplicationConfig.java
+++ b/bot/src/main/java/edu/java/bot/configuration/ApplicationConfig.java
@@ -4,6 +4,7 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
@@ -16,6 +17,7 @@ public record ApplicationConfig(
     String about,
     String description,
     @NotNull @Min(-12) @Max(12)
-    Integer zoneOffset
+    Integer zoneOffset,
+    List<String> ipWhitelist
 ) {
 }

--- a/bot/src/main/java/edu/java/bot/configuration/ClientConfig.java
+++ b/bot/src/main/java/edu/java/bot/configuration/ClientConfig.java
@@ -1,0 +1,26 @@
+package edu.java.bot.configuration;
+
+import edu.java.bot.client.scrapper.ScrapperClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+import static edu.java.bot.utils.retry.RetryFactory.create;
+import static edu.java.bot.utils.retry.RetryFactory.createFilter;
+
+@RequiredArgsConstructor
+@Configuration
+public class ClientConfig {
+
+    private final RetryConfig retryConfig;
+
+    @Bean
+    public ScrapperClient scrapperClient(
+        WebClient.Builder webClientBuilder,
+        @Value("${api-client.scrapper.base-url}") String baseUrl
+    ) {
+        webClientBuilder.filter(createFilter(create(retryConfig.scrapper())));
+        return new ScrapperClient(webClientBuilder, baseUrl);
+    }
+}

--- a/bot/src/main/java/edu/java/bot/configuration/ClientConfig.java
+++ b/bot/src/main/java/edu/java/bot/configuration/ClientConfig.java
@@ -1,11 +1,17 @@
 package edu.java.bot.configuration;
 
 import edu.java.bot.client.scrapper.ScrapperClient;
+import edu.java.bot.dto.response.ApiErrorResponse;
+import edu.java.bot.exception.ScrapperApiException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
 import static edu.java.bot.utils.retry.RetryFactory.create;
 import static edu.java.bot.utils.retry.RetryFactory.createFilter;
 
@@ -20,7 +26,25 @@ public class ClientConfig {
         WebClient.Builder webClientBuilder,
         @Value("${api-client.scrapper.base-url}") String baseUrl
     ) {
-        webClientBuilder.filter(createFilter(create(retryConfig.scrapper())));
+        webClientBuilder.filter(createFilter(create(retryConfig.scrapper())))
+            .filter(
+                ExchangeFilterFunction.ofResponseProcessor(
+                    ClientConfig::exchangeFilterResponseProcessor
+                )
+            );
         return new ScrapperClient(webClientBuilder, baseUrl);
+    }
+
+    private static Mono<ClientResponse> exchangeFilterResponseProcessor(ClientResponse response) {
+        HttpStatusCode status = response.statusCode();
+        if (status.isError()) {
+            return response.bodyToMono(ApiErrorResponse.class)
+                .flatMap(
+                    apiErrorResponse -> Mono.error(
+                        new ScrapperApiException(apiErrorResponse)
+                    )
+                );
+        }
+        return Mono.just(response);
     }
 }

--- a/bot/src/main/java/edu/java/bot/configuration/RetryConfig.java
+++ b/bot/src/main/java/edu/java/bot/configuration/RetryConfig.java
@@ -1,0 +1,18 @@
+package edu.java.bot.configuration;
+
+import edu.java.bot.utils.retry.RetryType;
+import java.time.Duration;
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "retry")
+public record RetryConfig(
+    WebClientRetryConfig scrapper
+) {
+    public record WebClientRetryConfig(
+        RetryType retryType,
+        int maxRetries,
+        Duration initialInterval,
+        List<Integer> codes
+    ) { }
+}

--- a/bot/src/main/java/edu/java/bot/handler/handlers/commands/ListUpdateHandler.java
+++ b/bot/src/main/java/edu/java/bot/handler/handlers/commands/ListUpdateHandler.java
@@ -3,14 +3,12 @@ package edu.java.bot.handler.handlers.commands;
 import com.pengrad.telegrambot.model.Update;
 import com.pengrad.telegrambot.request.AbstractSendRequest;
 import edu.java.bot.configuration.Command;
-import edu.java.bot.exception.ScrapperApiException;
 import edu.java.bot.handler.UpdateHandlerWithNext;
 import edu.java.bot.handler.util.HandlerUtils;
 import edu.java.bot.repository.ChatLinkRepository;
 import edu.java.bot.utils.MessagesUtils;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import static edu.java.bot.utils.MessagesUtils.createErrorMessage;
 import static edu.java.bot.utils.MessagesUtils.createMessage;
 import static edu.java.bot.utils.MessagesUtils.getLinksList;
 
@@ -27,22 +25,16 @@ public class ListUpdateHandler extends UpdateHandlerWithNext {
     @Override
     protected Optional<AbstractSendRequest<? extends AbstractSendRequest<?>>> doHandle(Update update) {
         var chatID = HandlerUtils.chatID(update);
-        try {
-            var links = chatLinkRepository.getLinks(chatID);
-            if (links.size() == 0) {
-                return Optional.of(
-                    createMessage(chatID, MessagesUtils.NO_LINKS_MESSAGE)
-                );
-            } else {
-                var linksList = links.links().stream().map(linkResponse -> linkResponse.url().toString()).toList();
-                return Optional.of(
-                    createMessage(chatID, getLinksList(linksList))
-                        .disableWebPagePreview(true)
-                );
-            }
-        } catch (ScrapperApiException e) {
+        var links = chatLinkRepository.getLinks(chatID);
+        if (links.size() == 0) {
             return Optional.of(
-                createErrorMessage(chatID, e.getApiErrorResponse().description())
+                createMessage(chatID, MessagesUtils.NO_LINKS_MESSAGE)
+            );
+        } else {
+            var linksList = links.links().stream().map(linkResponse -> linkResponse.url().toString()).toList();
+            return Optional.of(
+                createMessage(chatID, getLinksList(linksList))
+                    .disableWebPagePreview(true)
             );
         }
     }

--- a/bot/src/main/java/edu/java/bot/handler/handlers/commands/StartUpdateHandler.java
+++ b/bot/src/main/java/edu/java/bot/handler/handlers/commands/StartUpdateHandler.java
@@ -3,13 +3,11 @@ package edu.java.bot.handler.handlers.commands;
 import com.pengrad.telegrambot.model.Update;
 import com.pengrad.telegrambot.request.AbstractSendRequest;
 import edu.java.bot.configuration.Command;
-import edu.java.bot.exception.ScrapperApiException;
 import edu.java.bot.handler.UpdateHandlerWithNext;
 import edu.java.bot.handler.util.HandlerUtils;
 import edu.java.bot.repository.ChatLinkRepository;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import static edu.java.bot.utils.MessagesUtils.createErrorMessage;
 import static edu.java.bot.utils.MessagesUtils.createMessage;
 import static edu.java.bot.utils.MessagesUtils.getStartText;
 
@@ -27,15 +25,9 @@ public class StartUpdateHandler extends UpdateHandlerWithNext {
     protected Optional<AbstractSendRequest<? extends AbstractSendRequest<?>>> doHandle(Update update) {
         var user = HandlerUtils.user(update);
         var chatID = HandlerUtils.chatID(update);
-        try {
-            chatLinkRepository.addTgChat(chatID);
-            return Optional.of(
-                createMessage(chatID, getStartText(user.firstName()))
-            );
-        } catch (ScrapperApiException e) {
-            return Optional.of(
-                createErrorMessage(chatID, e.getApiErrorResponse().description())
-            );
-        }
+        chatLinkRepository.addTgChat(chatID);
+        return Optional.of(
+            createMessage(chatID, getStartText(user.firstName()))
+        );
     }
 }

--- a/bot/src/main/java/edu/java/bot/handler/handlers/commands/TrackUpdateHandler.java
+++ b/bot/src/main/java/edu/java/bot/handler/handlers/commands/TrackUpdateHandler.java
@@ -4,7 +4,6 @@ import com.pengrad.telegrambot.model.Update;
 import com.pengrad.telegrambot.request.AbstractSendRequest;
 import edu.java.bot.configuration.Command;
 import edu.java.bot.dto.request.scrapper.AddLinkRequest;
-import edu.java.bot.exception.ScrapperApiException;
 import edu.java.bot.handler.UpdateHandlerWithNext;
 import edu.java.bot.handler.util.HandlerUtils;
 import edu.java.bot.repository.ChatLinkRepository;
@@ -41,14 +40,6 @@ public class TrackUpdateHandler extends UpdateHandlerWithNext {
             chatLinkRepository.addLink(chatID, new AddLinkRequest(URI.create(tokens[1])));
             return Optional.of(
                 createMessage(chatID, getLinkAddedMessage(tokens[1]))
-            );
-        } catch (ScrapperApiException e) {
-            return Optional.of(
-                createErrorMessage(
-                    chatID,
-                    e.getApiErrorResponse().description(),
-                    getTrackExplanation(Command.TRACK.getCommand())
-                )
             );
         } catch (IllegalArgumentException e) {
             return Optional.of(

--- a/bot/src/main/java/edu/java/bot/handler/handlers/commands/UntrackUpdateHandler.java
+++ b/bot/src/main/java/edu/java/bot/handler/handlers/commands/UntrackUpdateHandler.java
@@ -5,7 +5,6 @@ import com.pengrad.telegrambot.model.User;
 import com.pengrad.telegrambot.request.AbstractSendRequest;
 import edu.java.bot.configuration.Command;
 import edu.java.bot.dto.request.scrapper.RemoveLinkRequest;
-import edu.java.bot.exception.ScrapperApiException;
 import edu.java.bot.handler.UpdateHandlerWithNext;
 import edu.java.bot.handler.util.HandlerUtils;
 import edu.java.bot.repository.ChatLinkRepository;
@@ -13,7 +12,6 @@ import java.net.URI;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import static edu.java.bot.handler.util.HandlerUtils.isCommand;
-import static edu.java.bot.utils.MessagesUtils.createErrorMessage;
 import static edu.java.bot.utils.MessagesUtils.createMessage;
 import static edu.java.bot.utils.MessagesUtils.getLinkRemovedMessage;
 import static edu.java.bot.utils.MessagesUtils.getTrackExplanation;
@@ -40,15 +38,9 @@ public class UntrackUpdateHandler extends UpdateHandlerWithNext {
             );
         }
         String link = tokens[1];
-        try {
-            chatLinkRepository.removeLink(chatID, new RemoveLinkRequest(URI.create(link)));
-            return Optional.of(
-                createMessage(chatID, getLinkRemovedMessage(link))
-            );
-        } catch (ScrapperApiException e) {
-            return Optional.of(
-                createErrorMessage(chatID, e.getApiErrorResponse().description())
-            );
-        }
+        chatLinkRepository.removeLink(chatID, new RemoveLinkRequest(URI.create(link)));
+        return Optional.of(
+            createMessage(chatID, getLinkRemovedMessage(link))
+        );
     }
 }

--- a/bot/src/main/java/edu/java/bot/message/processor/UserMessageProcessorChainImpl.java
+++ b/bot/src/main/java/edu/java/bot/message/processor/UserMessageProcessorChainImpl.java
@@ -2,12 +2,15 @@ package edu.java.bot.message.processor;
 
 import com.pengrad.telegrambot.model.Update;
 import com.pengrad.telegrambot.request.AbstractSendRequest;
+import edu.java.bot.exception.ScrapperApiException;
 import edu.java.bot.handler.HandlerProvider;
 import edu.java.bot.handler.UpdateHandlerWithNext;
 import edu.java.bot.handler.handlers.UpdateHandlerLogger;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import static edu.java.bot.handler.util.HandlerUtils.chatID;
+import static edu.java.bot.utils.MessagesUtils.createErrorMessage;
 
 @Service
 @Log4j2
@@ -27,6 +30,13 @@ public class UserMessageProcessorChainImpl implements UserMessageProcessor {
 
     @Override
     public AbstractSendRequest<? extends AbstractSendRequest<?>> process(Update update) {
-        return updateHandler.handle(update);
+        try {
+            return updateHandler.handle(update);
+        } catch (ScrapperApiException e) {
+            return createErrorMessage(
+                chatID(update),
+                e.getApiErrorResponse().description()
+            );
+        }
     }
 }

--- a/bot/src/main/java/edu/java/bot/service/RateLimiterService.java
+++ b/bot/src/main/java/edu/java/bot/service/RateLimiterService.java
@@ -1,0 +1,19 @@
+package edu.java.bot.service;
+
+import edu.java.bot.configuration.ApplicationConfig;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RateLimiterService {
+
+    private final List<String> ipWhitelist;
+
+    public RateLimiterService(ApplicationConfig applicationConfig) {
+        this.ipWhitelist = applicationConfig.ipWhitelist();
+    }
+
+    public boolean isSkipped(String ip) {
+        return ipWhitelist.contains(ip);
+    }
+}

--- a/bot/src/main/java/edu/java/bot/utils/retry/RetryFactory.java
+++ b/bot/src/main/java/edu/java/bot/utils/retry/RetryFactory.java
@@ -1,0 +1,65 @@
+package edu.java.bot.utils.retry;
+
+import edu.java.bot.configuration.RetryConfig;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import lombok.experimental.UtilityClass;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
+import reactor.util.retry.Retry;
+
+@UtilityClass
+public class RetryFactory {
+
+    Map<RetryType, Function<RetryConfig.WebClientRetryConfig, Retry>> map = new HashMap<>();
+
+    static {
+        map.put(RetryType.FIXED, webClientRetryConfig -> Retry
+            .fixedDelay(
+                webClientRetryConfig.maxRetries(),
+                webClientRetryConfig.initialInterval()
+            ).filter(createErrorFilter(webClientRetryConfig.codes()))
+        );
+        map.put(RetryType.LINEAR, webClientRetryConfig -> RetryLinear
+            .linear(
+                webClientRetryConfig.maxRetries(),
+                webClientRetryConfig.initialInterval()
+            ).filter(createErrorFilter(webClientRetryConfig.codes()))
+        );
+        map.put(RetryType.EXPONENTIAL, webClientRetryConfig -> Retry
+            .backoff(
+                webClientRetryConfig.maxRetries(),
+                webClientRetryConfig.initialInterval()
+            ).filter(createErrorFilter(webClientRetryConfig.codes()))
+        );
+    }
+
+    public static ExchangeFilterFunction createFilter(Retry retry) {
+        return (response, next) -> next.exchange(response)
+            .flatMap(clientResponse -> {
+                if (clientResponse.statusCode().isError()) {
+                    return clientResponse.createError();
+                } else {
+                    return Mono.just(clientResponse);
+                }
+            }).retryWhen(retry);
+    }
+
+    public static Retry create(RetryConfig.WebClientRetryConfig webClientRetryConfig) {
+        return map.get(webClientRetryConfig.retryType())
+            .apply(webClientRetryConfig);
+    }
+
+    private static Predicate<Throwable> createErrorFilter(List<Integer> codes) {
+        return throwable -> {
+            if (throwable instanceof WebClientResponseException webClientResponseException) {
+                return codes.contains(webClientResponseException.getStatusCode().value());
+            }
+            return true;
+        };
+    }
+}

--- a/bot/src/main/java/edu/java/bot/utils/retry/RetryLinear.java
+++ b/bot/src/main/java/edu/java/bot/utils/retry/RetryLinear.java
@@ -1,0 +1,73 @@
+package edu.java.bot.utils.retry;
+
+import java.time.Duration;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import lombok.RequiredArgsConstructor;
+import org.reactivestreams.Publisher;
+import org.springframework.retry.ExhaustedRetryException;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+import reactor.util.retry.Retry;
+
+@RequiredArgsConstructor
+public class RetryLinear extends Retry {
+
+    private final Duration maxBackoff = Duration.ofMillis(Long.MAX_VALUE);
+
+    private final long maxAttempts;
+
+    private final Duration minBackoff;
+
+    private final Predicate<Throwable> errorFilter;
+
+    private final Supplier<Scheduler> schedulerSupplier = Schedulers::parallel;
+
+    public static RetryLinear linear(long maxAttempts, Duration minBackoff) {
+        return new RetryLinear(maxAttempts, minBackoff, t -> true);
+    }
+
+    public RetryLinear filter(Predicate<Throwable> errorFilter) {
+        return new RetryLinear(
+            this.maxAttempts,
+            this.minBackoff,
+            errorFilter
+        );
+    }
+
+    @Override
+    public Publisher<?> generateCompanion(Flux<RetrySignal> t) {
+        return Flux.deferContextual(cv ->
+            t.contextWrite(cv)
+                .concatMap(retryWhenState -> {
+                    RetrySignal copy = retryWhenState.copy();
+                    Throwable currentFailure = copy.failure();
+                    long iteration = copy.totalRetries();
+                    if (currentFailure == null) {
+                        return Mono.error(
+                            new IllegalStateException("Retry.RetrySignal#failure() not expected to be null")
+                        );
+                    }
+                    if (!errorFilter.test(currentFailure)) {
+                        return Mono.error(currentFailure);
+                    }
+                    if (iteration >= maxAttempts) {
+                        return Mono.error(new ExhaustedRetryException("Retry exhausted: " + this));
+                    }
+                    Duration nextBackoff;
+                    try {
+                        nextBackoff = minBackoff.multipliedBy(iteration + 1);
+                        if (nextBackoff.compareTo(maxBackoff) > 0) {
+                            nextBackoff = maxBackoff;
+                        }
+                    } catch (ArithmeticException overflow) {
+                        nextBackoff = maxBackoff;
+                    }
+                    return Mono.delay(nextBackoff, schedulerSupplier.get()).contextWrite(cv);
+                })
+                .onErrorStop()
+        );
+    }
+}

--- a/bot/src/main/java/edu/java/bot/utils/retry/RetryType.java
+++ b/bot/src/main/java/edu/java/bot/utils/retry/RetryType.java
@@ -1,0 +1,8 @@
+package edu.java.bot.utils.retry;
+
+public enum RetryType {
+
+    FIXED,
+    LINEAR,
+    EXPONENTIAL
+}

--- a/bot/src/main/resources/application.yml
+++ b/bot/src/main/resources/application.yml
@@ -26,7 +26,7 @@ retry:
     retry-type: exponential
     max-retries: 3
     initial-interval: 5s
-    codes: 429, 500, 501, 502, 503, 504, 521, 522, 523, 524
+    codes: 408, 429, 500, 501, 502, 503, 504, 521, 522, 523, 524
 
 bucket4j:
   enabled: true

--- a/bot/src/main/resources/application.yml
+++ b/bot/src/main/resources/application.yml
@@ -4,12 +4,18 @@ app:
   about: Бот для отслеживания изменений на страницах
   description: С помощью этого бота вы можете отслеживать обновление контента на таких страницах, как stackoverflow и GitHub.
   zone-offset: 3
+  ip-whitelist: ${IP_WHITELIST:}
 
 spring:
   application:
     name: bot
   jackson:
     time-zone: UTC
+  cache:
+    cache-names:
+      - rate-limit-buckets
+    caffeine:
+      spec: maximumSize=100000,expireAfterAccess=3600s
 
 api-client:
   scrapper:
@@ -17,10 +23,33 @@ api-client:
 
 retry:
   scrapper:
-    retry-type: linear
+    retry-type: exponential
     max-retries: 3
-    initial-interval: 10s
-    codes: 500, 501, 502, 503, 504, 521, 522, 523, 524
+    initial-interval: 5s
+    codes: 429, 500, 501, 502, 503, 504, 521, 522, 523, 524
+
+bucket4j:
+  enabled: true
+  filters:
+    - cache-name: rate-limit-buckets
+      url: .*
+      http-status-code: TOO_MANY_REQUESTS
+      http-content-type: application/json
+      http-response-body: "{
+        \"description\": \"Слишком много запросов\",
+        \"status\": \"TOO_MANY_REQUESTS\",
+        \"exceptionName\": \"TooManyRequestsException.class\",
+        \"exceptionMessage\": \"Too many requests\",
+        \"stacktrace\": []
+      }"
+      rate-limits:
+        - cache-key: getRemoteAddr()
+          skip-condition: '@rateLimiterService.isSkipped(getRemoteAddr())'
+          bandwidths:
+            - capacity: 100
+              time: 1
+              unit: MINUTES
+              refill-speed: interval
 
 server:
   port: 8090

--- a/bot/src/main/resources/application.yml
+++ b/bot/src/main/resources/application.yml
@@ -15,6 +15,13 @@ api-client:
   scrapper:
     base-url: ${SCRAPPER_API_CLIENT_BASE_URL}
 
+retry:
+  scrapper:
+    retry-type: linear
+    max-retries: 3
+    initial-interval: 10s
+    codes: 500, 501, 502, 503, 504, 521, 522, 523, 524
+
 server:
   port: 8090
 

--- a/bot/src/test/java/edu/java/bot/handler/handlers/commands/ListUpdateHandlerTest.java
+++ b/bot/src/test/java/edu/java/bot/handler/handlers/commands/ListUpdateHandlerTest.java
@@ -22,10 +22,10 @@ import static edu.java.bot.handler.handlers.HandlerTestUtils.DEFAULT_CHAT_ID;
 import static edu.java.bot.handler.handlers.HandlerTestUtils.assertEqualsSendMessages;
 import static edu.java.bot.handler.handlers.HandlerTestUtils.mockedUpdateWithMessageWithText;
 import static edu.java.bot.utils.MessagesUtils.NO_LINKS_MESSAGE;
-import static edu.java.bot.utils.MessagesUtils.createErrorMessage;
 import static edu.java.bot.utils.MessagesUtils.createMessage;
 import static edu.java.bot.utils.MessagesUtils.getLinksList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -68,9 +68,8 @@ class ListUpdateHandlerTest {
                 List.of()
             )));
         Update update = HandlerTestUtils.mockedUpdateWithMessageWithText("no matter what");
-        SendMessage actual = (SendMessage) listUpdateHandler.doHandle(update)
-            .orElse(createMessage(DEFAULT_CHAT_ID));
-        assertEqualsSendMessages(actual, createErrorMessage(DEFAULT_CHAT_ID, description));
+        assertThatExceptionOfType(ScrapperApiException.class)
+            .isThrownBy(() -> listUpdateHandler.doHandle(update));
     }
 
     @Test

--- a/bot/src/test/java/edu/java/bot/handler/handlers/commands/StartUpdateHandlerTest.java
+++ b/bot/src/test/java/edu/java/bot/handler/handlers/commands/StartUpdateHandlerTest.java
@@ -19,10 +19,10 @@ import static edu.java.bot.handler.handlers.HandlerTestUtils.DEFAULT_CHAT_ID;
 import static edu.java.bot.handler.handlers.HandlerTestUtils.DEFAULT_USER_FNAME;
 import static edu.java.bot.handler.handlers.HandlerTestUtils.assertEqualsSendMessages;
 import static edu.java.bot.handler.handlers.HandlerTestUtils.mockedUpdateWithMessageWithText;
-import static edu.java.bot.utils.MessagesUtils.createErrorMessage;
 import static edu.java.bot.utils.MessagesUtils.createMessage;
 import static edu.java.bot.utils.MessagesUtils.getStartText;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
@@ -66,9 +66,8 @@ class StartUpdateHandlerTest {
                 List.of()
             )));
         Update update = HandlerTestUtils.mockedUpdateWithMessageWithText("no matter what");
-        SendMessage actual = (SendMessage) startUpdateHandler.doHandle(update)
-            .orElse(createMessage(DEFAULT_CHAT_ID));
-        assertEqualsSendMessages(actual, createErrorMessage(DEFAULT_CHAT_ID, description));
+        assertThatExceptionOfType(ScrapperApiException.class)
+            .isThrownBy(() -> startUpdateHandler.doHandle(update));
     }
 
     @Test

--- a/bot/src/test/java/edu/java/bot/handler/handlers/commands/TrackUpdateHandlerTest.java
+++ b/bot/src/test/java/edu/java/bot/handler/handlers/commands/TrackUpdateHandlerTest.java
@@ -22,11 +22,11 @@ import org.springframework.http.HttpStatus;
 import static edu.java.bot.handler.handlers.HandlerTestUtils.DEFAULT_CHAT_ID;
 import static edu.java.bot.handler.handlers.HandlerTestUtils.assertEqualsSendMessages;
 import static edu.java.bot.handler.handlers.HandlerTestUtils.mockedUpdateWithMessageWithText;
-import static edu.java.bot.utils.MessagesUtils.createErrorMessage;
 import static edu.java.bot.utils.MessagesUtils.createMessage;
 import static edu.java.bot.utils.MessagesUtils.getLinkAddedMessage;
 import static edu.java.bot.utils.MessagesUtils.getTrackExplanation;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -71,13 +71,8 @@ class TrackUpdateHandlerTest {
                 List.of()
             )));
         Update update = HandlerTestUtils.mockedUpdateWithMessageWithText("/track link");
-        SendMessage actual = (SendMessage) trackUpdateHandler.doHandle(update)
-            .orElse(createMessage(DEFAULT_CHAT_ID));
-        assertEqualsSendMessages(actual, createErrorMessage(
-            DEFAULT_CHAT_ID,
-            description,
-            getTrackExplanation(Command.TRACK.getCommand())
-        ));
+        assertThatExceptionOfType(ScrapperApiException.class)
+            .isThrownBy(() -> trackUpdateHandler.doHandle(update));
     }
 
     @Test

--- a/bot/src/test/java/edu/java/bot/handler/handlers/commands/UntrackUpdateHandlerTest.java
+++ b/bot/src/test/java/edu/java/bot/handler/handlers/commands/UntrackUpdateHandlerTest.java
@@ -21,11 +21,11 @@ import org.springframework.http.HttpStatus;
 import static edu.java.bot.handler.handlers.HandlerTestUtils.DEFAULT_CHAT_ID;
 import static edu.java.bot.handler.handlers.HandlerTestUtils.assertEqualsSendMessages;
 import static edu.java.bot.handler.handlers.HandlerTestUtils.mockedUpdateWithMessageWithText;
-import static edu.java.bot.utils.MessagesUtils.createErrorMessage;
 import static edu.java.bot.utils.MessagesUtils.createMessage;
 import static edu.java.bot.utils.MessagesUtils.getLinkRemovedMessage;
 import static edu.java.bot.utils.MessagesUtils.getTrackExplanation;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -70,9 +70,8 @@ class UntrackUpdateHandlerTest {
                 List.of()
             )));
         Update update = HandlerTestUtils.mockedUpdateWithMessageWithText("/track link");
-        SendMessage actual = (SendMessage) untrackUpdateHandler.doHandle(update)
-            .orElse(createMessage(DEFAULT_CHAT_ID));
-        assertEqualsSendMessages(actual, createErrorMessage(DEFAULT_CHAT_ID, description));
+        assertThatExceptionOfType(ScrapperApiException.class)
+            .isThrownBy(() -> untrackUpdateHandler.doHandle(update));
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,10 @@
         <!-- Other -->
         <jetbrains-annotations.version>24.1.0</jetbrains-annotations.version>
         <java-telegram-bot-api.version>7.0.1</java-telegram-bot-api.version>
+        <spring-boot-starter-cache.version>3.2.4</spring-boot-starter-cache.version>
+        <caffeine.version>3.1.8</caffeine.version>
+        <bucket4j-spring-boot-starter.version>0.12.5</bucket4j-spring-boot-starter.version>
+        <jcache.version>1.1.1</jcache.version>
 
         <!-- Tests -->
         <testcontainers.version>1.19.4</testcontainers.version>
@@ -94,6 +98,31 @@
                 <version>${springdoc-openapi.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.giffing.bucket4j.spring.boot.starter</groupId>
+                <artifactId>bucket4j-spring-boot-starter</artifactId>
+                <version>${bucket4j-spring-boot-starter.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-cache</artifactId>
+                <version>${spring-boot-starter-cache.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.cache</groupId>
+                <artifactId>cache-api</artifactId>
+                <version>${jcache.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.ben-manes.caffeine</groupId>
+                <artifactId>caffeine</artifactId>
+                <version>${caffeine.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.ben-manes.caffeine</groupId>
+                <artifactId>jcache</artifactId>
+                <version>${caffeine.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/scrapper/pom.xml
+++ b/scrapper/pom.xml
@@ -149,6 +149,30 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
+
+        <!-- Bucket4j -->
+        <dependency>
+            <groupId>com.giffing.bucket4j.spring.boot.starter</groupId>
+            <artifactId>bucket4j-spring-boot-starter</artifactId>
+        </dependency>
+
+        <!-- Cache -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-cache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.cache</groupId>
+            <artifactId>cache-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>jcache</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/scrapper/src/main/java/edu/java/scrapper/ScrapperApplication.java
+++ b/scrapper/src/main/java/edu/java/scrapper/ScrapperApplication.java
@@ -1,12 +1,13 @@
 package edu.java.scrapper;
 
 import edu.java.scrapper.configuration.ApplicationConfig;
+import edu.java.scrapper.configuration.RetryConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 @SpringBootApplication
-@EnableConfigurationProperties(ApplicationConfig.class)
+@EnableConfigurationProperties({ApplicationConfig.class, RetryConfig.class})
 public class ScrapperApplication {
     public static void main(String[] args) {
         SpringApplication.run(ScrapperApplication.class, args);

--- a/scrapper/src/main/java/edu/java/scrapper/ScrapperApplication.java
+++ b/scrapper/src/main/java/edu/java/scrapper/ScrapperApplication.java
@@ -5,9 +5,11 @@ import edu.java.scrapper.configuration.RetryConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cache.annotation.EnableCaching;
 
 @SpringBootApplication
 @EnableConfigurationProperties({ApplicationConfig.class, RetryConfig.class})
+@EnableCaching
 public class ScrapperApplication {
     public static void main(String[] args) {
         SpringApplication.run(ScrapperApplication.class, args);

--- a/scrapper/src/main/java/edu/java/scrapper/client/bot/BotClient.java
+++ b/scrapper/src/main/java/edu/java/scrapper/client/bot/BotClient.java
@@ -6,13 +6,11 @@ import edu.java.scrapper.dto.response.ApiErrorResponse;
 import edu.java.scrapper.exception.ApiException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatusCode;
-import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
-@Service
 public class BotClient extends AbstractJsonWebClient {
 
     private static final String UPDATES_URI = "/updates";

--- a/scrapper/src/main/java/edu/java/scrapper/configuration/ApplicationConfig.java
+++ b/scrapper/src/main/java/edu/java/scrapper/configuration/ApplicationConfig.java
@@ -2,6 +2,7 @@ package edu.java.scrapper.configuration;
 
 import jakarta.validation.constraints.NotNull;
 import java.time.Duration;
+import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
@@ -9,7 +10,8 @@ import org.springframework.validation.annotation.Validated;
 @ConfigurationProperties(prefix = "app", ignoreUnknownFields = false)
 public record ApplicationConfig(
     Scheduler scheduler,
-    DatabaseAccessType databaseAccessType
+    DatabaseAccessType databaseAccessType,
+    List<String> ipWhitelist
 ) {
     public record Scheduler(
         boolean enable,

--- a/scrapper/src/main/java/edu/java/scrapper/configuration/ApplicationConfig.java
+++ b/scrapper/src/main/java/edu/java/scrapper/configuration/ApplicationConfig.java
@@ -13,9 +13,9 @@ public record ApplicationConfig(
 ) {
     public record Scheduler(
         boolean enable,
-        @NotNull Duration interval, // in milliseconds
-        @NotNull Duration initialDelay, // in milliseconds
-        @NotNull Integer forceCheckDelay, // in minutes
+        @NotNull Duration interval,
+        @NotNull Duration initialDelay,
+        @NotNull Duration forceCheckDelay,
         @NotNull Integer checkLimit) {
     }
 

--- a/scrapper/src/main/java/edu/java/scrapper/configuration/RetryConfig.java
+++ b/scrapper/src/main/java/edu/java/scrapper/configuration/RetryConfig.java
@@ -1,0 +1,20 @@
+package edu.java.scrapper.configuration;
+
+import edu.java.scrapper.util.retry.RetryType;
+import java.time.Duration;
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "retry")
+public record RetryConfig(
+    WebClientRetryConfig bot,
+    WebClientRetryConfig github,
+    WebClientRetryConfig stackoverflow
+) {
+    public record WebClientRetryConfig(
+        RetryType retryType,
+        int maxRetries,
+        Duration initialInterval,
+        List<Integer> codes
+    ) { }
+}

--- a/scrapper/src/main/java/edu/java/scrapper/service/limiter/RateLimiterService.java
+++ b/scrapper/src/main/java/edu/java/scrapper/service/limiter/RateLimiterService.java
@@ -1,0 +1,19 @@
+package edu.java.scrapper.service.limiter;
+
+import edu.java.scrapper.configuration.ApplicationConfig;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RateLimiterService {
+
+    private final List<String> ipWhitelist;
+
+    public RateLimiterService(ApplicationConfig applicationConfig) {
+        this.ipWhitelist = applicationConfig.ipWhitelist();
+    }
+
+    public boolean isSkipped(String ip) {
+        return ipWhitelist.contains(ip);
+    }
+}

--- a/scrapper/src/main/java/edu/java/scrapper/service/links/LinksServiceJpaImpl.java
+++ b/scrapper/src/main/java/edu/java/scrapper/service/links/LinksServiceJpaImpl.java
@@ -89,6 +89,7 @@ public class LinksServiceJpaImpl extends LinksService {
     }
 
     @Override
+    @Transactional
     public void updateLink(Link link) {
         var linkEntity = jpaLinkRepository.findById(link.id())
             .orElseThrow(LinkNotFoundException::new); // no such link in links
@@ -97,6 +98,7 @@ public class LinksServiceJpaImpl extends LinksService {
     }
 
     @Override
+    @Transactional
     public List<Long> getChatIdsForLink(Link link) {
         var linkEntity = jpaLinkRepository.findById(link.id())
             .orElseThrow(LinkNotFoundException::new); // no such link in links
@@ -107,6 +109,7 @@ public class LinksServiceJpaImpl extends LinksService {
     }
 
     @Override
+    @Transactional
     public List<Link> listStaleLinks(int limit, Duration minTimeSinceLastCheck) {
         return jpaLinkRepository
             .findAllByLastCheckedAtIsBeforeOrderByLastCheckedAt(

--- a/scrapper/src/main/java/edu/java/scrapper/service/scheduler/LinkUpdatesScheduler.java
+++ b/scrapper/src/main/java/edu/java/scrapper/service/scheduler/LinkUpdatesScheduler.java
@@ -6,7 +6,6 @@ import edu.java.scrapper.dto.request.bot.LinkUpdate;
 import edu.java.scrapper.model.Link;
 import edu.java.scrapper.service.links.LinksService;
 import edu.java.scrapper.service.update.UpdateInfo;
-import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -28,7 +27,7 @@ public class LinkUpdatesScheduler {
         log.info("Updating...");
         var links = linksService.listStaleLinks(
             applicationConfig.scheduler().checkLimit(),
-            Duration.ofMinutes(applicationConfig.scheduler().forceCheckDelay())
+            applicationConfig.scheduler().forceCheckDelay()
         );
         links.forEach(link -> {
             try {

--- a/scrapper/src/main/java/edu/java/scrapper/service/tgchats/TgChatsServiceJpaImpl.java
+++ b/scrapper/src/main/java/edu/java/scrapper/service/tgchats/TgChatsServiceJpaImpl.java
@@ -6,6 +6,7 @@ import edu.java.scrapper.domain.jpa.repository.JpaLinkRepository;
 import edu.java.scrapper.exception.ChatAlreadyRegisteredException;
 import edu.java.scrapper.exception.ChatNotRegisteredException;
 import edu.java.scrapper.model.Chat;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -17,6 +18,7 @@ public class TgChatsServiceJpaImpl implements TgChatsService {
 
 
     @Override
+    @Transactional
     public void registerChat(Chat chat) {
         if (jpaChatRepository.existsById(chat.id())) {
             throw new ChatAlreadyRegisteredException();
@@ -25,6 +27,7 @@ public class TgChatsServiceJpaImpl implements TgChatsService {
     }
 
     @Override
+    @Transactional
     public void deleteChat(Long id) {
         var chatEntity = jpaChatRepository.findById(id)
             .orElseThrow(ChatNotRegisteredException::new);

--- a/scrapper/src/main/java/edu/java/scrapper/util/retry/RetryFactory.java
+++ b/scrapper/src/main/java/edu/java/scrapper/util/retry/RetryFactory.java
@@ -1,0 +1,65 @@
+package edu.java.scrapper.util.retry;
+
+import edu.java.scrapper.configuration.RetryConfig;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import lombok.experimental.UtilityClass;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
+import reactor.util.retry.Retry;
+
+@UtilityClass
+public class RetryFactory {
+
+    Map<RetryType, Function<RetryConfig.WebClientRetryConfig, Retry>> map = new HashMap<>();
+
+    static {
+        map.put(RetryType.FIXED, webClientRetryConfig -> Retry
+            .fixedDelay(
+                webClientRetryConfig.maxRetries(),
+                webClientRetryConfig.initialInterval()
+            ).filter(createErrorFilter(webClientRetryConfig.codes()))
+        );
+        map.put(RetryType.LINEAR, webClientRetryConfig -> RetryLinear
+            .linear(
+                webClientRetryConfig.maxRetries(),
+                webClientRetryConfig.initialInterval()
+            ).filter(createErrorFilter(webClientRetryConfig.codes()))
+        );
+        map.put(RetryType.EXPONENTIAL, webClientRetryConfig -> Retry
+            .backoff(
+                webClientRetryConfig.maxRetries(),
+                webClientRetryConfig.initialInterval()
+            ).filter(createErrorFilter(webClientRetryConfig.codes()))
+        );
+    }
+
+    public static ExchangeFilterFunction createFilter(Retry retry) {
+        return (response, next) -> next.exchange(response)
+            .flatMap(clientResponse -> {
+                if (clientResponse.statusCode().isError()) {
+                    return clientResponse.createError();
+                } else {
+                    return Mono.just(clientResponse);
+                }
+            }).retryWhen(retry);
+    }
+
+    public static Retry create(RetryConfig.WebClientRetryConfig webClientRetryConfig) {
+        return map.get(webClientRetryConfig.retryType())
+            .apply(webClientRetryConfig);
+    }
+
+    private static Predicate<Throwable> createErrorFilter(List<Integer> codes) {
+        return throwable -> {
+            if (throwable instanceof WebClientResponseException webClientResponseException) {
+                return codes.contains(webClientResponseException.getStatusCode().value());
+            }
+            return true;
+        };
+    }
+}

--- a/scrapper/src/main/java/edu/java/scrapper/util/retry/RetryLinear.java
+++ b/scrapper/src/main/java/edu/java/scrapper/util/retry/RetryLinear.java
@@ -1,0 +1,73 @@
+package edu.java.scrapper.util.retry;
+
+import java.time.Duration;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import lombok.RequiredArgsConstructor;
+import org.reactivestreams.Publisher;
+import org.springframework.retry.ExhaustedRetryException;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+import reactor.util.retry.Retry;
+
+@RequiredArgsConstructor
+public class RetryLinear extends Retry {
+
+    private final Duration maxBackoff = Duration.ofMillis(Long.MAX_VALUE);
+
+    private final long maxAttempts;
+
+    private final Duration minBackoff;
+
+    private final Predicate<Throwable> errorFilter;
+
+    private final Supplier<Scheduler> schedulerSupplier = Schedulers::parallel;
+
+    public static RetryLinear linear(long maxAttempts, Duration minBackoff) {
+        return new RetryLinear(maxAttempts, minBackoff, t -> true);
+    }
+
+    public RetryLinear filter(Predicate<Throwable> errorFilter) {
+        return new RetryLinear(
+            this.maxAttempts,
+            this.minBackoff,
+            errorFilter
+        );
+    }
+
+    @Override
+    public Publisher<?> generateCompanion(Flux<RetrySignal> t) {
+        return Flux.deferContextual(cv ->
+            t.contextWrite(cv)
+                .concatMap(retryWhenState -> {
+                    RetrySignal copy = retryWhenState.copy();
+                    Throwable currentFailure = copy.failure();
+                    long iteration = copy.totalRetries();
+                    if (currentFailure == null) {
+                        return Mono.error(
+                            new IllegalStateException("Retry.RetrySignal#failure() not expected to be null")
+                        );
+                    }
+                    if (!errorFilter.test(currentFailure)) {
+                        return Mono.error(currentFailure);
+                    }
+                    if (iteration >= maxAttempts) {
+                        return Mono.error(new ExhaustedRetryException("Retry exhausted: " + this));
+                    }
+                    Duration nextBackoff;
+                    try {
+                        nextBackoff = minBackoff.multipliedBy(iteration + 1);
+                        if (nextBackoff.compareTo(maxBackoff) > 0) {
+                            nextBackoff = maxBackoff;
+                        }
+                    } catch (ArithmeticException overflow) {
+                        nextBackoff = maxBackoff;
+                    }
+                    return Mono.delay(nextBackoff, schedulerSupplier.get()).contextWrite(cv);
+                })
+                .onErrorStop()
+        );
+    }
+}

--- a/scrapper/src/main/java/edu/java/scrapper/util/retry/RetryType.java
+++ b/scrapper/src/main/java/edu/java/scrapper/util/retry/RetryType.java
@@ -1,0 +1,8 @@
+package edu.java.scrapper.util.retry;
+
+public enum RetryType {
+
+    FIXED,
+    LINEAR,
+    EXPONENTIAL
+}

--- a/scrapper/src/main/resources/application.yml
+++ b/scrapper/src/main/resources/application.yml
@@ -31,6 +31,23 @@ api-client:
   bot:
     base-url: ${BOT_API_CLIENT_BASE_URL}
 
+retry:
+  bot:
+    retry-type: linear
+    max-retries: 3
+    initial-interval: 10s
+    codes: 500, 501, 502, 503, 504, 521, 522, 523, 524
+  github:
+    retry-type: linear
+    max-retries: 3
+    initial-interval: 10s
+    codes: 500, 501, 502, 503, 504, 521, 522, 523, 524
+  stackoverflow:
+    retry-type: linear
+    max-retries: 3
+    initial-interval: 10s
+    codes: 500, 501, 502, 503, 504, 521, 522, 523, 524
+
 server:
   port: 8080
 

--- a/scrapper/src/main/resources/application.yml
+++ b/scrapper/src/main/resources/application.yml
@@ -6,6 +6,7 @@ app:
     force-check-delay: 0
     check-limit: 10
   databaseAccessType: jpa
+  ip-whitelist: ${IP_WHITELIST:}
 
 spring:
   application:
@@ -21,6 +22,11 @@ spring:
   jpa:
     hibernate:
       ddl-auto: validate
+  cache:
+    cache-names:
+      - rate-limit-buckets
+    caffeine:
+      spec: maximumSize=100000,expireAfterAccess=3600s
 
 api-client:
   github:
@@ -31,22 +37,45 @@ api-client:
   bot:
     base-url: ${BOT_API_CLIENT_BASE_URL}
 
+bucket4j:
+  enabled: true
+  filters:
+    - cache-name: rate-limit-buckets
+      url: .*
+      http-status-code: TOO_MANY_REQUESTS
+      http-content-type: application/json
+      http-response-body: "{
+        \"description\": \"Too many requests\",
+        \"code\": \"TOO_MANY_REQUESTS\",
+        \"exceptionName\": \"TooManyRequestsException.class\",
+        \"exceptionMessage\": \"Too many requests\",
+        \"stacktrace\": []
+      }"
+      rate-limits:
+        - cache-key: getRemoteAddr()
+          skip-condition: '@rateLimiterService.isSkipped(getRemoteAddr())'
+          bandwidths:
+            - capacity: 100
+              time: 1
+              unit: MINUTES
+              refill-speed: interval
+
 retry:
   bot:
     retry-type: linear
     max-retries: 3
     initial-interval: 10s
-    codes: 500, 501, 502, 503, 504, 521, 522, 523, 524
+    codes: 429,500, 501, 502, 503, 504, 521, 522, 523, 524
   github:
     retry-type: linear
     max-retries: 3
     initial-interval: 10s
-    codes: 500, 501, 502, 503, 504, 521, 522, 523, 524
+    codes: 429, 500, 501, 502, 503, 504, 521, 522, 523, 524
   stackoverflow:
     retry-type: linear
     max-retries: 3
     initial-interval: 10s
-    codes: 500, 501, 502, 503, 504, 521, 522, 523, 524
+    codes: 429, 500, 501, 502, 503, 504, 521, 522, 523, 524
 
 server:
   port: 8080

--- a/scrapper/src/main/resources/application.yml
+++ b/scrapper/src/main/resources/application.yml
@@ -65,17 +65,17 @@ retry:
     retry-type: linear
     max-retries: 3
     initial-interval: 10s
-    codes: 429,500, 501, 502, 503, 504, 521, 522, 523, 524
+    codes: 408, 429,500, 501, 502, 503, 504, 521, 522, 523, 524
   github:
     retry-type: linear
     max-retries: 3
     initial-interval: 10s
-    codes: 429, 500, 501, 502, 503, 504, 521, 522, 523, 524
+    codes: 408, 429, 500, 501, 502, 503, 504, 521, 522, 523, 524
   stackoverflow:
     retry-type: linear
     max-retries: 3
     initial-interval: 10s
-    codes: 429, 500, 501, 502, 503, 504, 521, 522, 523, 524
+    codes: 408, 429, 500, 501, 502, 503, 504, 521, 522, 523, 524
 
 server:
   port: 8080

--- a/scrapper/src/test/java/edu/java/scrapper/ScrapperApplicationTest.java
+++ b/scrapper/src/test/java/edu/java/scrapper/ScrapperApplicationTest.java
@@ -3,9 +3,11 @@ package edu.java.scrapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest
+@DirtiesContext
 @TestPropertySource(properties = {
     "BOT_API_CLIENT_BASE_URL=http://localhost:8090"
 })

--- a/scrapper/src/test/java/edu/java/scrapper/domain/repository/ChatLinkRepositoryTest.java
+++ b/scrapper/src/test/java/edu/java/scrapper/domain/repository/ChatLinkRepositoryTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +19,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
+@DirtiesContext
 @Log4j2
 @TestPropertySource(properties = {
     "BOT_API_CLIENT_BASE_URL=http://localhost:8090"

--- a/scrapper/src/test/java/edu/java/scrapper/domain/repository/ChatRepositoryTest.java
+++ b/scrapper/src/test/java/edu/java/scrapper/domain/repository/ChatRepositoryTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.dao.DuplicateKeyException;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @SpringBootTest
+@DirtiesContext
 @Log4j2
 @TestPropertySource(properties = {
     "BOT_API_CLIENT_BASE_URL=http://localhost:8090"

--- a/scrapper/src/test/java/edu/java/scrapper/domain/repository/LinkRepositoryTest.java
+++ b/scrapper/src/test/java/edu/java/scrapper/domain/repository/LinkRepositoryTest.java
@@ -11,12 +11,14 @@ import lombok.extern.log4j.Log4j2;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.transaction.annotation.Transactional;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
+@DirtiesContext
 @Log4j2
 @TestPropertySource(properties = {
     "BOT_API_CLIENT_BASE_URL=http://localhost:8090"

--- a/scrapper/src/test/java/edu/java/scrapper/service/links/LinksServiceTest.java
+++ b/scrapper/src/test/java/edu/java/scrapper/service/links/LinksServiceTest.java
@@ -23,6 +23,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.TestPropertySource;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,6 +31,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 
 @SpringBootTest
+@DirtiesContext
 @TestPropertySource(properties = {
     "BOT_API_CLIENT_BASE_URL=http://localhost:8090"
 })
@@ -187,19 +189,19 @@ public abstract class LinksServiceTest<T extends LinksService> extends Integrati
             .params("link4", OffsetDateTime.now().minusHours(4), OffsetDateTime.now())
             .update();
         var link1 = jdbcClient.sql("SELECT * FROM links WHERE url = ?")
-            .param("link1")
+            .params("link1")
             .query(Link.class)
             .single();
         var link2 = jdbcClient.sql("SELECT * FROM links WHERE url = ?")
-            .param("link2")
+            .params("link2")
             .query(Link.class)
             .single();
         var link3 = jdbcClient.sql("SELECT * FROM links WHERE url = ?")
-            .param("link3")
+            .params("link3")
             .query(Link.class)
             .single();
         var link4 = jdbcClient.sql("SELECT * FROM links WHERE url = ?")
-            .param("link4")
+            .params("link4")
             .query(Link.class)
             .single();
         var staleLinks = linksService.listStaleLinks(1, Duration.ofMinutes(90));

--- a/scrapper/src/test/java/edu/java/scrapper/service/tgchats/TgChatsServiceTest.java
+++ b/scrapper/src/test/java/edu/java/scrapper/service/tgchats/TgChatsServiceTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @SpringBootTest
+@DirtiesContext
 @TestPropertySource(properties = {
     "BOT_API_CLIENT_BASE_URL=http://localhost:8090"
 })


### PR DESCRIPTION
# Выполнена домашняя работа №7

Добавлен механизм повторного запроса для всех http клиентов.
Для retry конфигурируются следующие параметры:
 - политика повтора: `fixed`, `linear`, `exponential`
 - максимальное количество повторов (не учитывая первый)
 - время первого интервала (в линейном также является шагом прогрессии)
 - список кодов ошибок для которых применяется retry фильтр

Для фиксированной и экспоненциальной политик повтора были использованы готовые решения из `reactor.util.retry.Retry`:
 - `Retry.fixedDelay()`
 - `Retry.backoff()`

Для линейной политики повтора был написан собственный класс `RetryLinear`, отнаследованный от `Retry`.

Демонстрация настроек конфигурации:
![image](https://github.com/Nick-552/link-tracker/assets/115263760/bc0148e3-fd04-4a6e-b0d0-088c0556dcab)

Также был добавлен rate limiter на основе ip адресов для каждого endpointa. 
Для этого был использован Bucket4j Spring Boot Starter.

Пример конфигурации rate limitera
![image](https://github.com/Nick-552/link-tracker/assets/115263760/98c22d13-c3f5-40b7-b035-f75514788fe8)

